### PR TITLE
Style for Portafolio pages

### DIFF
--- a/app/assets/stylesheets/portfolios.scss
+++ b/app/assets/stylesheets/portfolios.scss
@@ -1,1 +1,39 @@
 @import "bootstrap";
+
+:root {
+  --jumbotron-padding-y: 3rem;
+}
+
+.jumbotron {
+  padding-top: var(--jumbotron-padding-y);
+  padding-bottom: var(--jumbotron-padding-y);
+  margin-bottom: 0;
+  background-color: #fff;
+}
+@media (min-width: 768px) {
+  .jumbotron {
+    padding-top: calc(var(--jumbotron-padding-y) * 2);
+    padding-bottom: calc(var(--jumbotron-padding-y) * 2);
+  }
+}
+
+.jumbotron p:last-child {
+  margin-bottom: 0;
+}
+
+.jumbotron-heading {
+  font-weight: 300;
+}
+
+.jumbotron .container {
+  max-width: 40rem;
+}
+
+footer {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+footer p {
+  margin-bottom: .25rem;
+}

--- a/app/assets/stylesheets/portfolios.scss
+++ b/app/assets/stylesheets/portfolios.scss
@@ -37,3 +37,11 @@ footer {
 footer p {
   margin-bottom: .25rem;
 }
+
+/*
+ * Custom styles
+ */
+
+.portfolio-form {
+ padding: 20px;
+}

--- a/app/views/layouts/portfolio.html.erb
+++ b/app/views/layouts/portfolio.html.erb
@@ -19,16 +19,7 @@
     </header>
 
     <main role="main">
-      <section class="jumbotron text-center">
-        <div class="container">
-          <h1 class="jumbotron-heading">Album example</h1>
-          <p class="lead text-muted">Something short and leading about the collection below—its contents, the creator, etc. Make it short and sweet, but not too short so folks don't simply skip over it entirely.</p>
-          <p>
-            <a href="#" class="btn btn-primary my-2">Main call to action</a>
-            <a href="#" class="btn btn-secondary my-2">Secondary action</a>
-          </p>
-        </div>
-      </section>
+      <%= render 'shared/portfolio_masthead' %>
       <%= yield %>    
     </main>
 

--- a/app/views/layouts/portfolio.html.erb
+++ b/app/views/layouts/portfolio.html.erb
@@ -17,7 +17,7 @@
     <%= render 'shared/portfolio_nav' %>
 
     <main role="main">
-      <%= render 'shared/portfolio_masthead' %>
+      <%= render 'shared/portfolio_masthead' unless logged_in?(:side_admin) %>
       <%= yield %>    
     </main>
 

--- a/app/views/layouts/portfolio.html.erb
+++ b/app/views/layouts/portfolio.html.erb
@@ -15,37 +15,7 @@
 
   <body>
     <header>
-      <div class="collapse bg-dark" id="navbarHeader">
-        <div class="container">
-          <div class="row">
-            <div class="col-sm-8 col-md-7 py-4">
-              <h4 class="text-white">About</h4>
-              <p class="text-muted">Add some information about the album below, the author, or any other background context. Make it a few sentences long so folks can pick up some informative tidbits. Then, link them off to some social networking sites or contact information.</p>
-              <%= render 'shared/nav', location: 'top' %>
-            </div>
-            <div class="col-sm-4 offset-md-1 py-4">
-              <h4 class="text-white">Contact</h4>
-              <ul class="list-unstyled">
-                <li><a href="#" class="text-white">Follow on Twitter</a></li>
-                <li><a href="#" class="text-white">Like on Facebook</a></li>
-                <li><a href="#" class="text-white">Email me</a></li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="navbar navbar-dark bg-dark shadow-sm">
-        <div class="container d-flex justify-content-between">
-          <a href="#" class="navbar-brand d-flex align-items-center">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
-            <strong>Album</strong>
-          </a>
-          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-          </button>
-        </div>
-      </div>
+      <%= render 'shared/portfolio_nav' %>
     </header>
 
     <main role="main">

--- a/app/views/layouts/portfolio.html.erb
+++ b/app/views/layouts/portfolio.html.erb
@@ -14,25 +14,14 @@
   </head>
 
   <body>
-    <header>
-      <%= render 'shared/portfolio_nav' %>
-    </header>
+    <%= render 'shared/portfolio_nav' %>
 
     <main role="main">
       <%= render 'shared/portfolio_masthead' %>
       <%= yield %>    
     </main>
 
-    <footer class="text-muted">
-      <div class="container">
-        <p class="float-right">
-          <a href="#">Back to top</a>
-        </p>
-        <p>Album example is &copy; Bootstrap, but please download and customize it for yourself!</p>
-        <p>New to Bootstrap? <a href="../../">Visit the homepage</a> or read our <a href="../../getting-started/">getting started guide</a>.</p>
-      </div>
-    </footer>
-
+    <%= render 'shared/portfolio_footer' %>
     <!-- <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
  -->

--- a/app/views/layouts/portfolio.html.erb
+++ b/app/views/layouts/portfolio.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= @page_title %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -12,15 +14,67 @@
   </head>
 
   <body>
-    <p class="notice"><%= notice %></p>
+    <header>
+      <div class="collapse bg-dark" id="navbarHeader">
+        <div class="container">
+          <div class="row">
+            <div class="col-sm-8 col-md-7 py-4">
+              <h4 class="text-white">About</h4>
+              <p class="text-muted">Add some information about the album below, the author, or any other background context. Make it a few sentences long so folks can pick up some informative tidbits. Then, link them off to some social networking sites or contact information.</p>
+              <%= render 'shared/nav', location: 'top' %>
+            </div>
+            <div class="col-sm-4 offset-md-1 py-4">
+              <h4 class="text-white">Contact</h4>
+              <ul class="list-unstyled">
+                <li><a href="#" class="text-white">Follow on Twitter</a></li>
+                <li><a href="#" class="text-white">Like on Facebook</a></li>
+                <li><a href="#" class="text-white">Email me</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="navbar navbar-dark bg-dark shadow-sm">
+        <div class="container d-flex justify-content-between">
+          <a href="#" class="navbar-brand d-flex align-items-center">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
+            <strong>Album</strong>
+          </a>
+          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <main role="main">
+      <section class="jumbotron text-center">
+        <div class="container">
+          <h1 class="jumbotron-heading">Album example</h1>
+          <p class="lead text-muted">Something short and leading about the collection below—its contents, the creator, etc. Make it short and sweet, but not too short so folks don't simply skip over it entirely.</p>
+          <p>
+            <a href="#" class="btn btn-primary my-2">Main call to action</a>
+            <a href="#" class="btn btn-secondary my-2">Secondary action</a>
+          </p>
+        </div>
+      </section>
+      <%= yield %>    
+    </main>
+
+    <footer class="text-muted">
+      <div class="container">
+        <p class="float-right">
+          <a href="#">Back to top</a>
+        </p>
+        <p>Album example is &copy; Bootstrap, but please download and customize it for yourself!</p>
+        <p>New to Bootstrap? <a href="../../">Visit the homepage</a> or read our <a href="../../getting-started/">getting started guide</a>.</p>
+      </div>
+    </footer>
+
+    <!-- <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
-
-    <%= render 'shared/nav', location: 'top' %>
-    
-    <%= login_helper %>
-
-    <%= yield %>
-    
+ -->
     <%= source_helper('application') %>
   </body>
 </html>

--- a/app/views/portfolios/_form.html.erb
+++ b/app/views/portfolios/_form.html.erb
@@ -1,29 +1,38 @@
 <%= form_for(@portfolio_item) do |form| %>
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label :title %>
+        <%= form.text_field :title, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :subtitle %>
+        <%= form.text_field :subtitle, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label :body %>
+        <%= form.text_area :body, class: "form-control", rows: 15 %>
+      </div>
+    </div>
   </div>
 
-  <div class="field">
-    <%= form.label :subtitle %>
-    <%= form.text_field :subtitle %>
-  </div>
+  <div class="col-md-12">
+    <h3>Technologies used:</h3>
+    <div>
+      <%= form.fields_for :technologies do |technology_form|%>
+        <div class="form-group">
+          <%= technology_form.label :name %>
+          <%= technology_form.text_field :name, class: "form-control" %>
+        </div>
+      <% end %>
+    </div>
 
-  <div class="field">
-    <%= form.label :body %>
-    <%= form.text_area :body %>
-  </div>
-
-  <ul>
-    <%= form.fields_for :technologies do |technology_form|%>
-      <li>
-        <%= technology_form.label :name %>
-        <%= technology_form.text_field :name %>
-      </li>
-    <% end %>
-  </ul>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
+    <div class="form-group">
+      <%= form.submit "Submit", class: "btn btn-primary" %>
+    </div>
+  </div> 
 <% end %>

--- a/app/views/portfolios/_form.html.erb
+++ b/app/views/portfolios/_form.html.erb
@@ -34,5 +34,8 @@
     <div class="form-group">
       <%= form.submit "Submit", class: "btn btn-primary" %>
     </div>
+    <div class="form-group">
+      <%= link_to "Back to portfolio page", portfolios_path %>
+    </div>
   </div> 
 <% end %>

--- a/app/views/portfolios/_portfolio_item.html.erb
+++ b/app/views/portfolios/_portfolio_item.html.erb
@@ -8,17 +8,6 @@
         <%= portfolio_item.subtitle %>
         <%#= portfolio_item.body %>
       </p>
-      
-      <!-- <div class="d-flex justify-content-between align-items-center">
-        <div class="btn-group">
-          <%# if logged_in?(:side_admin) %>
-            <%#= link_to "Edit", edit_portfolio_path(portfolio_item), class: "btn btn-sm btn-outline-secondary" %>
-            <%#= link_to 'Delete Portfolio Item', portfolio_path(portfolio_item), 
-              method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-outline-secondary" %>
-          <%# end %>
-        </div>
-      </div>
- -->
     </div>
   </div>
 </div>

--- a/app/views/portfolios/_portfolio_item.html.erb
+++ b/app/views/portfolios/_portfolio_item.html.erb
@@ -1,11 +1,24 @@
-<p><%= link_to portfolio_item.title, portfolio_show_path(portfolio_item) %></p>
-<p><%= portfolio_item.subtitle %></p>
-<p><%= portfolio_item.body %></p>
-
-<%= image_tag portfolio_item.thumb_image unless portfolio_item.thumb_image.nil? %>
-
-<% if logged_in?(:side_admin) %>
-  <%= link_to "Edit", edit_portfolio_path(portfolio_item) %>
-  <%= link_to 'Delete Portfolio Item', portfolio_path(portfolio_item), 
-    method: :delete, data: { confirm: 'Are you sure?' } %>
-<% end %>
+ <div class="col-md-4">
+  <div class="card mb-4 shadow-sm">
+    <%= image_tag(portfolio_item.thumb_image, class: "card-img-top") unless portfolio_item.thumb_image.nil? %>
+    
+    <div class="card-body">
+      <p class="card-text">
+        <span><%= link_to portfolio_item.title, portfolio_show_path(portfolio_item) %></span>
+        <%= portfolio_item.subtitle %>
+        <%#= portfolio_item.body %>
+      </p>
+      
+      <!-- <div class="d-flex justify-content-between align-items-center">
+        <div class="btn-group">
+          <%# if logged_in?(:side_admin) %>
+            <%#= link_to "Edit", edit_portfolio_path(portfolio_item), class: "btn btn-sm btn-outline-secondary" %>
+            <%#= link_to 'Delete Portfolio Item', portfolio_path(portfolio_item), 
+              method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-outline-secondary" %>
+          <%# end %>
+        </div>
+      </div>
+ -->
+    </div>
+  </div>
+</div>

--- a/app/views/portfolios/edit.html.erb
+++ b/app/views/portfolios/edit.html.erb
@@ -1,3 +1,5 @@
-<h1>Edit this portfolio item</h1> 
+<div class="container portfolio-form">
+  <h1>Edit this portfolio item</h1> 
 
-<%= render 'form', portfolio_item: @portfolio_item %>
+  <%= render 'form', portfolio_item: @portfolio_item %>
+</div>

--- a/app/views/portfolios/index.html.erb
+++ b/app/views/portfolios/index.html.erb
@@ -1,5 +1,8 @@
-<h1>Portfolios</h1>
-
-<%= link_to "Create new item", new_portfolio_path if logged_in?(:side_admin) %>
-
-<%= render partial: 'portfolio_item', collection: @portfolio_items %>
+ <div class="album py-5 bg-light">
+  <div class="container">
+    <%= link_to "Create new item", new_portfolio_path if logged_in?(:side_admin) %>
+    <div class="row">
+        <%= render partial: 'portfolio_item', collection: @portfolio_items %>
+    </div>
+  </div>
+</div>

--- a/app/views/portfolios/new.html.erb
+++ b/app/views/portfolios/new.html.erb
@@ -1,3 +1,5 @@
-<h1>Create a new portfolio item</h1> 
+<div class="container portfolio-form">
+  <h1>Create a new portfolio item</h1> 
 
-<%= render 'form', portfolio_item: @portfolio_item %>
+  <%= render 'form', portfolio_item: @portfolio_item %>
+</div>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -1,9 +1,21 @@
-<%= image_tag @portfolio_item.main_image %>
-<h1><%= @portfolio_item.title %></h1>
-<em><%= @portfolio_item.subtitle %></em>
-<p><%= @portfolio_item.body %></p>
+<div class="container">
+  <div class="row">
+    <div class="col-md-7">
+      <%= image_tag @portfolio_item.main_image %>
+    </div>
+    <div class="col-md-5">
+      <h1><%= @portfolio_item.title %></h1>
+      <hr>
+      <em><%= @portfolio_item.subtitle %></em>
+      <p><%= @portfolio_item.body %></p>
+      <hr>
+      <h2>Technologies used:</h2>
+      
+      <% @portfolio_item.technologies.each do |t| %>
+        <p><%= t.name %></p>
+      <% end %>
 
-<h2>Technologies used:</h2>
-<% @portfolio_item.technologies.each do |t| %>
-  <p><%= t.name %></p>
-<% end %>
+      <%= link_to "View all portfolios", portfolios_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -2,7 +2,19 @@
   <div class="row">
     <div class="col-md-7">
       <%= image_tag @portfolio_item.main_image %>
+
+      <div class="d-flex justify-content-between align-items-center">
+        <div class="btn-group">
+          <% if logged_in?(:side_admin) %>
+            <%= link_to "Edit", edit_portfolio_path(@portfolio_item), class: "btn btn-sm btn-outline-secondary" %>
+            <%= link_to 'Delete Portfolio Item', portfolio_path(@portfolio_item), 
+              method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-outline-secondary" %>
+          <% end %>
+          <%= link_to "Back to portfolio page", portfolios_path %>
+        </div>
+      </div>    
     </div>
+
     <div class="col-md-5">
       <h1><%= @portfolio_item.title %></h1>
       <hr>
@@ -14,8 +26,6 @@
       <% @portfolio_item.technologies.each do |t| %>
         <p><%= t.name %></p>
       <% end %>
-
-      <%= link_to "View all portfolios", portfolios_path %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_portfolio_footer.html.erb
+++ b/app/views/shared/_portfolio_footer.html.erb
@@ -1,0 +1,8 @@
+<footer class="text-muted">
+  <div class="container">
+    <p class="float-right">
+      <a href="#">Back to top</a>
+    </p>
+    <p><%= copyright_generator %></p>
+  </div>
+</footer>

--- a/app/views/shared/_portfolio_masthead.html.erb
+++ b/app/views/shared/_portfolio_masthead.html.erb
@@ -1,0 +1,12 @@
+<section class="jumbotron text-center">
+  <div class="container">
+    <h1 class="jumbotron-heading">My Portfolio</h1>
+    <p class="lead text-muted">
+      Something short and leading about the collection below—its contents, the creator, etc. Make it short and sweet, but not too short so folks don't simply skip over it entirely.
+    </p>  
+    <p>
+      <%= link_to "Find out more about me", about_me_path, class: "btn btn-sm btn-outline-secondary" %>
+      <%= link_to "My Blog", blogs_path, class: "btn btn-sm btn-outline-secondary" %>
+    </p>
+  </div>
+</section>

--- a/app/views/shared/_portfolio_nav.html.erb
+++ b/app/views/shared/_portfolio_nav.html.erb
@@ -1,35 +1,36 @@
-<div class="collapse bg-dark" id="navbarHeader">
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-8 col-md-7 py-4">
-        <h4 class="text-white">About</h4>
-        <p class="text-muted">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </div>
-      <div class="col-sm-4 offset-md-1 py-4">
-        <h4 class="text-white">Explore</h4>
-        <ul class="list-unstyled">
-          <li><%= link_to "Home", root_path, class: 'text-white' %></li>
-          <li><%= link_to "About Me", about_me_path, class: 'text-white' %></li>
-          <li><%= link_to "Contact", contact_path, class: 'text-white' %></li>
-          <li><%= link_to "Blog", blogs_path, class: 'text-white' %></li>
-          <li><%= link_to "Portfolio", portfolios_path, class: 'text-white' %></li>
-          <li><%= login_helper 'btn btn-sm btn-outline-secondary' %></li>
-        </ul>
+<header>
+  <div class="collapse bg-dark" id="navbarHeader">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-8 col-md-7 py-4">
+          <h4 class="text-white">About</h4>
+          <p class="text-muted">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </div>
+        <div class="col-sm-4 offset-md-1 py-4">
+          <h4 class="text-white">Explore</h4>
+          <ul class="list-unstyled">
+            <li><%= link_to "Home", root_path, class: 'text-white' %></li>
+            <li><%= link_to "About Me", about_me_path, class: 'text-white' %></li>
+            <li><%= link_to "Contact", contact_path, class: 'text-white' %></li>
+            <li><%= link_to "Blog", blogs_path, class: 'text-white' %></li>
+            <li><%= link_to "Portfolio", portfolios_path, class: 'text-white' %></li>
+            <li><%= login_helper 'btn btn-sm btn-outline-secondary' %></li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<div class="navbar navbar-dark bg-dark shadow-sm">
-  <div class="container d-flex justify-content-between">
-    <a href="#" class="navbar-brand d-flex align-items-center">
-      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
-      <strong>Bianca Velázquez</strong>
-    </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
+  <div class="navbar navbar-dark bg-dark shadow-sm">
+    <div class="container d-flex justify-content-between">
+      <a href="#" class="navbar-brand d-flex align-items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
+        <strong>Bianca Velázquez</strong>
+      </a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+    </div>
   </div>
-</div>
-
+</header>
         

--- a/app/views/shared/_portfolio_nav.html.erb
+++ b/app/views/shared/_portfolio_nav.html.erb
@@ -1,0 +1,35 @@
+<div class="collapse bg-dark" id="navbarHeader">
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-8 col-md-7 py-4">
+        <h4 class="text-white">About</h4>
+        <p class="text-muted">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
+      <div class="col-sm-4 offset-md-1 py-4">
+        <h4 class="text-white">Explore</h4>
+        <ul class="list-unstyled">
+          <li><%= link_to "Home", root_path, class: 'text-white' %></li>
+          <li><%= link_to "About Me", about_me_path, class: 'text-white' %></li>
+          <li><%= link_to "Contact", contact_path, class: 'text-white' %></li>
+          <li><%= link_to "Blog", blogs_path, class: 'text-white' %></li>
+          <li><%= link_to "Portfolio", portfolios_path, class: 'text-white' %></li>
+          <li><%= login_helper 'btn btn-sm btn-outline-secondary' %></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="navbar navbar-dark bg-dark shadow-sm">
+  <div class="container d-flex justify-content-between">
+    <a href="#" class="navbar-brand d-flex align-items-center">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
+      <strong>Bianca Velázquez</strong>
+    </a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+  </div>
+</div>
+
+        


### PR DESCRIPTION
- Sets initial styling for portafolio layout
- Adds css for portafolio pages
- creates partial for: `_portafolio_item.html.erb`, `_portfolio_nav.html.erb`, `_portfolio_masthead.html.erb`, `_portfolio_footer.html.erb`
- Adds styling to show portfolio page
- Hides masthead in portfolio pages for admin users
- styling for: portfolio _form, portfolio new, edit portfolio
- Adds `back_to_portfolio` link in `edit `and `show` pages
- Adds `Edit` and `delete` links to` show` page