### PR TITLE
Global Markdown, to enable to use it on portfolio text area as welll

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,4 +71,24 @@ module ApplicationHelper
   def alert_generator msg
     js add_gritter(msg, title: "#{current_user.name.capitalize}'s Portfolio", stucky: false)
   end
+
+  class CodeRayify < Redcarpet::Render::HTML
+    def block_code(code, language)
+      CodeRay.scan(code, language || :text).div
+    end
+  end
+
+  def markdown(text)
+    coderayified = CodeRayify.new(filter_html: true, hard_wrap: true)
+
+    options = {
+      fenced_code_blocks: true,
+      no_intra_emphasis: true,
+      autolink: true,
+      lax_html_blocks: true
+    }
+
+    markdown_to_html = Redcarpet::Markdown.new(coderayified, options)
+    markdown_to_html.render(text).html_safe
+  end
 end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -3,26 +3,6 @@ module BlogsHelper
     image_tag "https://www.gravatar.com/avatar/#{Digest::MD5::hexdigest(user.email)}", width: 64, class: "card-img-left"
   end
 
-  class CodeRayify < Redcarpet::Render::HTML
-    def block_code(code, language)
-      CodeRay.scan(code, language).div
-    end
-  end
-
-  def markdown(text)
-    coderayified = CodeRayify.new(filter_html: true, hard_wrap: true)
-
-    options = {
-      fenced_code_blocks: true,
-      no_intra_emphasis: true,
-      autolink: true,
-      lax_html_blocks: true
-    }
-
-    markdown_to_html = Redcarpet::Markdown.new(coderayified, options)
-    markdown_to_html.render(text).html_safe
-  end
-
   def blog_status_color(blog)
     'color: gray;' if blog.draft?
   end

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -20,7 +20,7 @@
       <h1><%= @portfolio_item.title %></h1>
       <hr>
       <em><%= @portfolio_item.subtitle %></em>
-      <p><%= @portfolio_item.body %></p>
+      <p><%= markdown @portfolio_item.body %></p>
       <hr>
       <h2>Technologies used:</h2>
       


### PR DESCRIPTION
- Removes the setup from `blog_helper` and moves into `application_helper`
- Fix bug related to `CodeRay.scan(code, language).div`, missing default language in case of Nil
 solution => `CodeRay.scan(code, language  || :text).div`
- Applies markdown to  `portfolio_item.body` when `show`

This will enable to have links in the text area 